### PR TITLE
feature: Extended the TestKit with new test methods

### DIFF
--- a/src/main/scala/com/suprnation/actor/dispatch/mailbox/Mailboxes.scala
+++ b/src/main/scala/com/suprnation/actor/dispatch/mailbox/Mailboxes.scala
@@ -79,7 +79,7 @@ object Mailboxes {
 
       @inline override val isSuspended: F[Boolean] = false.pure[F]
 
-      @inline override val isClosed: F[Boolean] = false.pure[F]
+      @inline override val isClosed: F[Boolean] = true.pure[F]
 
       @inline override val resume: F[Unit] =
         Concurrent[F].raiseError(

--- a/src/main/scala/com/suprnation/actor/test/TestKit.scala
+++ b/src/main/scala/com/suprnation/actor/test/TestKit.scala
@@ -38,7 +38,7 @@ trait TestKit {
       Async[F].monotonic
         .flatMap { now =>
           Async[F].raiseUnless(now < stop)(
-            new TimeoutException(s"timeout ${max} expired: $message")
+            new TimeoutException(s"timeout $max expired: $message")
           )
         }
         .andWait(max.min(interval))
@@ -61,6 +61,21 @@ trait TestKit {
       // .flatTap(buf => IO.println(s">>> $buf"))
     } yield ()
 
+  def expectMsgPF[F[+_]: Async: Console](actor: ActorRef[F, ?], timeout: FiniteDuration = 1.minute)(
+      pF: PartialFunction[Any, Unit]
+  ): F[Unit] =
+    for {
+      _ <- awaitCond(
+        actor.messageBuffer.map { case (_, messages) =>
+          messages.exists(pF.isDefinedAt)
+        },
+        timeout,
+        100.millis,
+        s"partial function did not match any of the received messages"
+      )
+      _ <- actor.messageBuffer.map { case (_, messages) => messages.collectFirst(pF) }
+    } yield ()
+
   def expectNoMsg[F[+_]: Async](
       actor: ActorRef[F, ?],
       timeout: FiniteDuration = 1.minute
@@ -75,10 +90,16 @@ trait TestKit {
       )
     } yield ()
 
+  def expectTerminated[F[+_]: Async](actor: ActorRef[F, ?]): F[Unit] =
+    Async[F].ifM(actor.cell.flatMap(_.isTerminated))(
+      Async[F].unit,
+      Async[F].raiseError(new Exception("Expected actor to be terminated but was still alive"))
+    )
+
   def within[F[_]: Async, T](min: FiniteDuration, max: FiniteDuration)(f: => F[T]): F[T] = for {
     start <- Async[F].monotonic
     result <- f.timeout(max).adaptError { case t: TimeoutException =>
-      new TimeoutException(s"timeout ${max} expired while executing block")
+      new TimeoutException(s"timeout $max expired while executing block")
     }
     finish <- Async[F].monotonic
     diff = finish - start

--- a/src/test/scala/com/suprnation/actor/test/TestKitSpec.scala
+++ b/src/test/scala/com/suprnation/actor/test/TestKitSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 SuprNation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.suprnation.actor.test
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.suprnation.actor.debug.TrackingActor
+import com.suprnation.actor.{Actor, ActorSystem}
+import com.suprnation.typelevel.actors.syntax.ActorSystemDebugOps
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
+class TestKitSpec extends AsyncFlatSpec with Matchers with TestKit {
+
+  "expectTerminated" should "assert true when the actor is terminated" in {
+    ActorSystem[IO]()
+      .use { actorSystem =>
+        for {
+          actorRef <- actorSystem.actorOf(Actor.empty[IO, Any])
+
+          _ <- actorRef.stop
+          _ <- actorSystem.waitForIdle()
+
+          _ <- expectTerminated(actorRef)
+        } yield succeed
+      }
+      .unsafeToFuture()
+  }
+
+  "expectTerminated" should "throw exception when the actor is alive" in {
+    ActorSystem[IO]()
+      .use { actorSystem =>
+        for {
+          actorRef <- actorSystem.actorOf(Actor.empty[IO, Any])
+          isTerminated <- expectTerminated(actorRef).as(true).handleError(_ => false)
+        } yield isTerminated should be(false)
+      }
+      .unsafeToFuture()
+  }
+
+  "expectMsgPF" should "succeed when actor received expected message defined in partial function" in {
+    ActorSystem[IO]()
+      .use { actorSystem =>
+        for {
+          actorRef <- actorSystem.actorOf(
+            TrackingActor.create[IO, Any, Any](
+              Actor.withReceive[IO, Any] { case _ =>
+                IO.unit
+              }
+            )
+          )
+
+          _ <- actorRef ! "Hello"
+
+          _ <- actorSystem.waitForIdle()
+          _ <- expectMsgPF(actorRef, 1 second) {
+            case s: String if s == "Hello" => ()
+          }
+        } yield succeed
+      }
+      .unsafeToFuture()
+  }
+
+  "expectMsgPF" should "fail when actor did not receive expected message defined in partial function" in {
+    ActorSystem[IO]()
+      .use { actorSystem =>
+        for {
+          actorRef <- actorSystem.actorOf(
+            TrackingActor.create[IO, Any, Any](
+              Actor.withReceive[IO, Any] { case _ =>
+                IO.unit
+              }
+            )
+          )
+
+          _ <- actorRef ! "Bye"
+
+          receivedMessage <- expectMsgPF(actorRef, 1 second) {
+            case s: String if s == "Hello" => ()
+          }.as(true).handleError(_ => false)
+        } yield receivedMessage should be(false)
+      }
+      .unsafeToFuture()
+  }
+
+}


### PR DESCRIPTION
1. Added expectMsgPF, expectTerminated, and receiveWhile to the TestKit along with a TestKitSpec test class.
2. Fixed issue with DeadLetter Mailbox returning false for Mailbox.isTerminated. This is incorrect because when the actor is stopped and mailboxes are switched, calling actor.cell.isClosed would return false. This is now updated to return true instead.