### PR TITLE
feature: Added checkSchedulerIdle Flag to ActorSystem.waitForIdle Method 

### DIFF
--- a/src/test/scala/com/suprnation/actor/lifecycle/DeathWatchSpec.scala
+++ b/src/test/scala/com/suprnation/actor/lifecycle/DeathWatchSpec.scala
@@ -42,9 +42,8 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       watcher <- actorSystem.actorOf(Actor.empty[IO, DeathWatchRequest], "watcher")
       watchee <- createChild(watcher)(Actor.empty[IO, DeathWatchRequest], "watchee")
 
-      waitAll = List(watcher, watchee).waitForIdle
       _ <- watch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       watcherWatchContext <- getWatchContext(watcher)
       watcheeWatchContext <- getWatchContext(watchee)
@@ -75,7 +74,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       _ <- watch(parent, child1)
       _ <- watch(parent, child2)
 
-      _ <- List(grandParent, parent, child1, child2).waitForIdle
+      _ <- actorSystem.waitForIdle()
 
       grandParentWatchContext <- getWatchContext(grandParent)
       parentWatchContext <- getWatchContext(parent)
@@ -120,7 +119,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
 
       _ <- watch(parent, grandParent)
 
-      _ <- List(grandParent, parent).waitForIdle
+      _ <- actorSystem.waitForIdle()
 
       grandParentWatchContext <- getWatchContext(grandParent)
       parentWatchContext <- getWatchContext(parent)
@@ -144,7 +143,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
 
       _ <- watch(sol, centauri)
 
-      _ <- List(sol, centauri).waitForIdle
+      _ <- actorSystem.waitForIdle()
 
       solWatchContext <- getWatchContext(sol)
       centauriWatchContext <- getWatchContext(centauri)
@@ -178,7 +177,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       _ <- watch(centauri, proximaC)
       _ <- watch(proximaC, earth) // They're watching
 
-      _ <- List(sol, centauri, earth, proximaB, proximaC).waitForIdle
+      _ <- actorSystem.waitForIdle()
 
       solWatchContext <- getWatchContext(sol)
       earthWatchContext <- getWatchContext(earth)
@@ -238,7 +237,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
 
         _ <- watch(watcher, watchee, "a")
         _ <- watch(watcher, watchee, "b")
-        _ <- List(watcher, watchee).waitForIdle
+        _ <- actorSystem.waitForIdle()
       } yield ()).unsafeToFuture()
     }.map(e =>
       e.getMessage should endWith(
@@ -253,7 +252,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       watcher <- actorSystem.actorOf(Actor.empty[IO, DeathWatchRequest], "watcher")
 
       _ <- watch(watcher, watcher)
-      _ <- List(watcher).waitForIdle
+      _ <- actorSystem.waitForIdle()
       watcherWatchContext <- getWatchContext(watcher)
     } yield watcherWatchContext).unsafeToFuture().map { case watcherWatchContext =>
       watcherWatchContext.watching shouldBe empty
@@ -290,11 +289,10 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       watcher <- actorSystem.actorOf(Actor.empty[IO, DeathWatchRequest], "watcher")
       watchee <- createChild(watcher)(Actor.empty[IO, DeathWatchRequest], "watchee")
 
-      waitAll = List(watcher, watchee).waitForIdle
       _ <- watch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
       _ <- unwatch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       watcherWatchContext <- getWatchContext(watcher)
       watcheeWatchContext <- getWatchContext(watchee)
@@ -321,14 +319,13 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       _ <- watch(parent, child1)
       _ <- watch(parent, child2)
 
-      waitAll = List(grandParent, parent, child1, child2).waitForIdle
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       _ <- unwatch(grandParent, parent)
       _ <- unwatch(grandParent, child1)
       _ <- unwatch(parent, child1)
       _ <- unwatch(parent, child2)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       grandParentWatchContext <- getWatchContext(grandParent)
       parentWatchContext <- getWatchContext(parent)
@@ -370,12 +367,11 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       _ <- watch(parent, child1)
       _ <- watch(parent, child2)
 
-      waitAll = List(grandParent, parent, child1, child2).waitForIdle
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       _ <- unwatch(grandParent, parent)
       _ <- unwatch(parent, child2)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       grandParentWatchContext <- getWatchContext(grandParent)
       parentWatchContext <- getWatchContext(parent)
@@ -414,12 +410,10 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       centauri <- actorSystem.actorOf(Actor.empty[IO, DeathWatchRequest], "alphaCentauri")
 
       _ <- watch(sol, centauri)
-
-      waitAll = List(sol, centauri).waitForIdle
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       _ <- unwatch(sol, centauri)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       solWatchContext <- getWatchContext(sol)
       centauriWatchContext <- getWatchContext(centauri)
@@ -451,8 +445,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       _ <- watch(centauri, proximaC)
       _ <- watch(proximaC, earth)
 
-      waitAll = List(sol, centauri, earth, proximaB, proximaC).waitForIdle
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       _ <- unwatch(sol, earth)
       _ <- unwatch(earth, centauri)
@@ -461,7 +454,7 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       _ <- unwatch(centauri, proximaB)
       _ <- unwatch(centauri, proximaC)
       _ <- unwatch(proximaC, earth)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       solWatchContext <- getWatchContext(sol)
       earthWatchContext <- getWatchContext(earth)
@@ -506,12 +499,11 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       watcher <- actorSystem.actorOf(Actor.empty[IO, DeathWatchRequest], "watcher")
       watchee <- createChild(watcher)(Actor.empty[IO, DeathWatchRequest], "watchee")
 
-      waitAll = List(watcher, watchee).waitForIdle
       _ <- watch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
       _ <- unwatch(watcher, watchee)
       _ <- unwatch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       watcherWatchContext <- getWatchContext(watcher)
       watcheeWatchContext <- getWatchContext(watchee)
@@ -531,11 +523,10 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       watcher <- actorSystem.actorOf(Actor.empty[IO, DeathWatchRequest], "watcher")
       watchee <- createChild(watcher)(Actor.empty[IO, DeathWatchRequest], "watchee")
 
-      waitAll = List(watcher, watchee).waitForIdle
       _ <- watch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
       _ <- unwatch(watcher, watcher)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       watcherWatchContext <- getWatchContext(watcher)
       watcheeWatchContext <- getWatchContext(watchee)
@@ -556,14 +547,13 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       actorSystem <- ActorSystem[IO]("Death Watch 15", (_: Any) => IO.unit).allocated.map(_._1)
       watcher <- actorSystem.actorOf(Actor.ignoring[IO, DeathWatchRequest], "watcher")
       watchee <- actorSystem.actorOf(Actor.ignoring[IO, DeathWatchRequest], "watchee")
-      userGuardian <- actorSystem.guardian.get
-      waitAll = List(watcher, watchee, userGuardian).waitForIdle
+
       _ <- watch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
       _ <- stop(watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
       _ <- unwatch(watcher, watchee)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       watcherWatchContext <- getWatchContext(watcher)
       watcheeWatchContext <- getWatchContext(watchee)
@@ -584,12 +574,10 @@ class DeathWatchSpec extends AsyncFlatSpec with Matchers {
       parent <- actorSystem.actorOf(Actor.ignoring[IO, DeathWatchRequest], "parent")
       watcher <- createChild(parent)(Actor.ignoring[IO, DeathWatchRequest], "watcher")
       watchee <- createChild(parent)(Actor.ignoring[IO, DeathWatchRequest], "watchee")
-      userGuardian <- actorSystem.guardian.get
 
-      waitAll = List(watcher, watchee, userGuardian).waitForIdle
       _ <- watch(watcher, watchee)
       _ <- stop(watcher)
-      _ <- waitAll
+      _ <- actorSystem.waitForIdle()
 
       watcherWatchContext <- getWatchContext(watcher)
       watcheeWatchContext <- getWatchContext(watchee)

--- a/src/test/scala/com/suprnation/typelevel/actors/syntax/ActorSystemDebugSyntaxSpec.scala
+++ b/src/test/scala/com/suprnation/typelevel/actors/syntax/ActorSystemDebugSyntaxSpec.scala
@@ -1,0 +1,127 @@
+package com.suprnation.typelevel.actors.syntax
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, IO}
+import com.suprnation.actor.{Actor, ActorSystem}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
+class ActorSystemDebugSyntaxSpec extends AsyncFlatSpec with Matchers {
+
+  it should "wait for schedule to be completed before progressing" in {
+    ActorSystem[IO]()
+      .use(actorSystem =>
+        for {
+          deferred <- Deferred[IO, Unit]
+          _ <- actorSystem.scheduler.scheduleOnce_(300 millis)(deferred.complete(()))
+          _ <- actorSystem.waitForIdle(maxTimeout = 500 millis)
+
+          // Race deferred.get (which should complete after scheduler) with a fail
+          result <- IO.race(
+            deferred.get,
+            IO.sleep(50 millis) *> IO(fail("waitForIdle did not wait long enough"))
+          )
+        } yield result.isLeft should be(true)
+      )
+      .unsafeToFuture()
+  }
+
+  it should "wait for all schedules to be completed before progressing" in {
+    ActorSystem[IO]()
+      .use(actorSystem =>
+        for {
+          deferred1 <- Deferred[IO, Unit]
+          _ <- actorSystem.scheduler.scheduleOnce_(300 millis)(deferred1.complete(()))
+          deferred2 <- Deferred[IO, Unit]
+          _ <- actorSystem.scheduler.scheduleOnce_(200 millis)(deferred2.complete(()))
+
+          _ <- actorSystem.waitForIdle(maxTimeout = 500 millis)
+
+          // Race deferred.get (which should complete after scheduler) with a fail
+          result <- IO.race(
+            deferred1.get *> deferred2.get,
+            IO.sleep(50 millis) *> IO(fail("waitForIdle did not wait long enough"))
+          )
+        } yield result.isLeft should be(true)
+      )
+      .unsafeToFuture()
+  }
+
+  it should "not wait for any schedules to be completed before progressing" in {
+    ActorSystem[IO]()
+      .use(actorSystem =>
+        for {
+          deferred1 <- Deferred[IO, Unit]
+          _ <- actorSystem.scheduler.scheduleOnce_(500 millis)(deferred1.complete(()))
+          deferred2 <- Deferred[IO, Unit]
+          _ <- actorSystem.scheduler.scheduleOnce_(400 millis)(deferred2.complete(()))
+
+          _ <- actorSystem.waitForIdle(checkSchedulerIdle = false, maxTimeout = 200 millis)
+
+          // IO.sleep should win the race as waitForIdle is configured to ignore schedules
+          result <- IO.race(
+            IO.sleep(50 millis),
+            deferred1.get *> deferred2.get *> IO(
+              fail("waitForIdle should not have waited for the scheduler")
+            )
+          )
+        } yield result.isLeft should be(true)
+      )
+      .unsafeToFuture()
+  }
+
+  it should "wait for mailboxes to be empty before progressing" in {
+    ActorSystem[IO]()
+      .use(actorSystem =>
+        for {
+          deferred <- Deferred[IO, Unit]
+          actorRef <- actorSystem.actorOf(Actor.withReceive[IO, String] { case _ =>
+            IO.sleep(300 millis) *> deferred.complete(())
+          })
+          _ <- actorRef ! "Greetings"
+
+          _ <- actorSystem.waitForIdle(maxTimeout = 500 millis)
+
+          // Race deferred.get (which should complete after receive) with a fail
+          result <- IO.race(
+            deferred.get,
+            IO.sleep(50 millis) *> IO(fail("waitForIdle did not wait long enough"))
+          )
+        } yield result.isLeft should be(true)
+      )
+      .unsafeToFuture()
+  }
+
+  it should "wait for scheduler and all mailboxes to be empty before progressing" in {
+    ActorSystem[IO]()
+      .use(actorSystem =>
+        for {
+          mailboxDeferred <- Deferred[IO, Unit]
+          actorRef <- actorSystem.actorOf(Actor.withReceive[IO, String] { case _ =>
+            IO.sleep(300 millis) *> mailboxDeferred.complete(())
+          })
+          _ <- actorRef ! "Greetings"
+          _ <- actorRef ! "Greetings again!"
+
+          schedulerDeferred <- Deferred[IO, Unit]
+          _ <- actorSystem.scheduler.scheduleOnce_(400 millis)(schedulerDeferred.complete(()))
+
+          // Sequential process 1 includes first + second message: 300ms + 300ms
+          // Sequential process 2 includes scheduler: 400ms
+          // Minimum time to wait would be 600ms from process 1
+          _ <- actorSystem.waitForIdle(maxTimeout = 800 millis)
+
+          // Race mailboxDeferred and schedulerDeferred (which should complete after receive and scheduler) with a fail
+          result <- IO.race(
+            mailboxDeferred.get *> schedulerDeferred.get,
+            IO.sleep(50 millis) *> IO(fail("waitForIdle did not wait long enough"))
+          )
+        } yield result.isLeft should be(true)
+      )
+      .unsafeToFuture()
+  }
+
+}


### PR DESCRIPTION
### Description
In certain scenarios, actors may have long-running scheduled tasks running in the background. The current implementation of `waitForIdle` prevents testing intermediate states between messages because it waits for the scheduler to become idle, causing the test to hang.

This PR introduces a new `checkSchedulerIdle` flag in the `waitForIdle` method. When this flag is set to `false`, the scheduler's idle state is not checked, allowing tests to proceed without waiting for the scheduler to be empty.

### Example
```
ActorSystem[IO]().use(actorSystem =>
  for {
    deferred <- Deferred[IO, Unit]
    _ <- actorSystem.scheduler.scheduleOnce_(500 millis)(deferred.complete(()))

    _ <- actorSystem.waitForIdle(checkSchedulerIdle = false, maxTimeout = 200 millis)

    // IO.sleep should win the race as waitForIdle is configured to ignore schedules
    result <- IO.race(
      IO.sleep(50 millis),
      deferred.get *> IO(
        fail("waitForIdle should not have waited for the scheduler")
      )
    )
  } yield result.isLeft should be(true)
)
```