### PR TITLE
feat: Allow FSM preStart to initialize state

### DIFF
--- a/src/main/scala/com/suprnation/actor/fsm/StateManager.scala
+++ b/src/main/scala/com/suprnation/actor/fsm/StateManager.scala
@@ -37,9 +37,8 @@ trait StateContext[F[+_], S, D, Request, Response] {
   def isTimerActive(name: String): F[Boolean]
 }
 
-trait StateManager[F[+_], S, D, Request, Response]
+trait PreStartContext[F[+_], S, D, Request, Response]
     extends StateContext[F, S, D, Request, Response] {
-
   def forMax(timeoutData: Option[(FiniteDuration, Request)]): F[State[S, D, Request, Response]]
 
   def goto(nextStateName: S): F[State[S, D, Request, Response]]
@@ -51,6 +50,10 @@ trait StateManager[F[+_], S, D, Request, Response]
   def stop(reason: Reason): F[State[S, D, Request, Response]]
 
   def stop(reason: Reason, stateData: D): F[State[S, D, Request, Response]]
+}
+
+trait StateManager[F[+_], S, D, Request, Response]
+    extends PreStartContext[F, S, D, Request, Response] {
 
   def stayAndReply(
       replyValue: Response,

--- a/src/test/scala/com/suprnation/actor/fsm/broadcast/TreenodeFSMActor.scala
+++ b/src/test/scala/com/suprnation/actor/fsm/broadcast/TreenodeFSMActor.scala
@@ -90,7 +90,7 @@ object TreenodeFsmActor {
               .using(startingData.andAlso(pong.processedBy))
           }
       }
-    }.withPreStart(_ => IO.sleep(creationDelay))
+    }.withPreStart(c => IO.sleep(creationDelay) >> c.stay())
       .withConfig(createConfig(name, dataRef))
       .withSupervisorStrategy(AllForOneStrategy[IO]() { case _: Throwable => Escalate })
       .startWith(InProgress, TreenodeData(Queue()))


### PR DESCRIPTION
### Summary

Provides a custom `PreStartContext` to the FSM `preStart` allowing it more methods from the state manager, so it can change state.

**This is a breaking change as the signature of the FSM `preStart` method has changed.**

The reason we are doing this is to allow the state to be dynamically initialized and depend on other features of the FSM actor, most notably children actors created at `preStart`. 

### More details/justification for this change

Specifically we had a situation in our codebase where the initial state and data of an FSM were determined by data that was persisted in a database and loaded at `preStart`. The initialisation phase included the creation of child actors and some interaction with them before we determine the resulting state of the FSM. 

Very strictly speaking, this breaks FSM semantics by allowing a change of state without a transition triggered by a message. Akka deals with this much more loosely by having a null initial state that you can set at any point using `startWith` (which you could forget to use) and optionally then verify with `initialize`. 

In cats-actors, `startWith` and `initialize` are methods you chain from the `FSMBuilder`, meaning that you do not yet have an actor ref and so cannot spawn children actors (for instance). So if you want your initial state to depend on some initialisation result from your children actors, that can be very tricky to achieve. You could have a custom initialisation state (but then you have to check it each time and ensure you initialise before any other messages come through), or wrap your FSM in a proxy actor that handles initialisation and escalation, but these solutions add a lot of overhead in the code to achieve a rather simple thing. 

The current solution solves the problem "in one line", but needs to be used responsibly. e.g. if you develop an FSM for someone else to use, it may not be obvious to them that the initial state may change at `preStart`.